### PR TITLE
Add axios to "dependencies" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "gcp-cloud-build-bitbucket",
   "version": "1.0.0",
   "dependencies": {
-    "@google-cloud/pubsub": "^0.18.0"
+    "@google-cloud/pubsub": "^0.18.0",
+    "axios": "0.19.0"
   },
   "description": "Sends build status of a commit from GCP Cloud Build to Bitbucket.",
   "main": "index.js",


### PR DESCRIPTION
Axios was only listed in the devDependencies, but it's required for the cloud function to run.